### PR TITLE
Initial upload

### DIFF
--- a/suspicious_use_of_csharp_console.yml
+++ b/suspicious_use_of_csharp_console.yml
@@ -1,0 +1,27 @@
+title: Suspicious Use of CSharp Interactive Console
+id: a9e416a8-e613-4f8b-88b8-a7d1d1af2f61
+status: experimental
+description: Detects the execution of CSharp interactive console by PowerShell
+references:
+    - https://redcanary.com/blog/detecting-attacks-leveraging-the-net-framework/
+author: Michael R. (@nahamike01)
+date: 2020/03/08
+tags:
+    - attack.execution
+    - attack.t1127
+logsource:
+    product: windows
+    service: sysmon
+detection:
+    selection1:
+        EventID: 1
+        Image:
+            - '*\csi.exe'
+        ParentImage:
+            - '*\powershell.exe'
+        OriginalFileName:
+            - 'csi.exe'
+    condition: selection1
+falsepositives:
+    - Possible depending on environment. Pair with other factors such as net connections, command-line args, etc.
+level: high


### PR DESCRIPTION
Sigma rule to detect suspicious use of CSharp interactive console, csi.exe. Rule also checks to ensure the original file name is csi.exe in the event an attacker changes the name of the binary.